### PR TITLE
Reduce Puma memory usage in high-allocation actions

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -130,17 +130,15 @@ class ProjectsController < ApplicationController
   end
 
   def packages
-    # Use database query instead of loading all projects into memory
-    # Select only needed columns to reduce memory usage
     @projects = Project.reviewed
-                       .where.not(packages: [nil, []])
+                       .where("packages IS NOT NULL AND jsonb_array_length(packages::jsonb) > 0")
                        .select(:id, :name, :url, :packages, :score, :repository, :description,
                                :keywords, :category, :sub_category, :last_synced_at)
+                       .order(Arel.sql(<<~SQL.squish))
+                         (SELECT COALESCE(SUM((elem->>'downloads')::bigint), 0)
+                          FROM jsonb_array_elements(packages::jsonb) AS elem) DESC
+                       SQL
                        .limit(500)
-                       .to_a
-                       .select { |p| p.packages.present? }
-                       .sort_by { |p| p.packages.sum { |pkg| pkg['downloads'] || 0 } }
-                       .reverse
   end
 
   def images

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1939,8 +1939,7 @@ class Project < ApplicationRecord
         ORDER BY cnt DESC
       SQL
       rows = connection.select_rows(sanitize_sql_array([sql, { category: category }]))
-      keywords = rows.map(&:first) - ignore_words
-      keywords
+      rows.map(&:first) - ignore_words
     end
   end
 
@@ -1959,8 +1958,7 @@ class Project < ApplicationRecord
         ORDER BY cnt DESC
       SQL
       rows = connection.select_rows(sanitize_sql_array([sql, { subcategory: subcategory }]))
-      keywords = rows.map(&:first) - ignore_words
-      keywords
+      rows.map(&:first) - ignore_words
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -37,15 +37,18 @@ class Project < ApplicationRecord
   }
 
   def self.facets(scope)
-    subquery = scope.where.not(keywords: []).select("unnest(keywords) AS kw").to_sql
-    keyword_counts = connection
-      .select_rows("SELECT kw, count(*) FROM (#{subquery}) AS t GROUP BY kw ORDER BY count(*) DESC")
-      .to_h { |kw, count| [kw, count.to_i] }
+    cache_key = "project_facets_#{Digest::MD5.hexdigest(scope.to_sql)}"
+    Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+      subquery = scope.where.not(keywords: []).select("unnest(keywords) AS kw").to_sql
+      keyword_counts = connection
+        .select_rows("SELECT kw, count(*) FROM (#{subquery}) AS t GROUP BY kw ORDER BY count(*) DESC LIMIT 100")
+        .to_h { |kw, count| [kw, count.to_i] }
 
-    language_counts = scope.where("repository ->> 'language' IS NOT NULL")
-      .group("repository ->> 'language'").order(Arel.sql("count(*) DESC")).count
+      language_counts = scope.where("repository ->> 'language' IS NOT NULL")
+        .group("repository ->> 'language'").order(Arel.sql("count(*) DESC")).count
 
-    { "keywords" => keyword_counts, "language" => language_counts }
+      { "keywords" => keyword_counts, "language" => language_counts }
+    end
   end
 
   validates :url, presence: true, uniqueness: { case_sensitive: false }
@@ -1923,41 +1926,41 @@ class Project < ApplicationRecord
 
   def self.unique_keywords_for_category(category)
     Rails.cache.fetch("project_unique_keywords_category_#{category}", expires_in: 24.hours) do
-      # Get all keywords from all categories
-      all_keywords = Project.where.not(category: category).pluck(:keywords).flatten
-
-      # Get keywords from the specific category
-      category_keywords = Project.where(category: category).pluck(:keywords).flatten
-
-      # Get keywords that only appear in the specific category
-      unique_keywords = category_keywords - all_keywords
-
-      # remove stop words
-      unique_keywords = unique_keywords - ignore_words
-
-      # Group the unique keywords by their values and sort them by the size of each group
-      sorted_keywords = unique_keywords.group_by { |keyword| keyword }.sort_by { |keyword, occurrences| -occurrences.size }.map(&:first)
-      sorted_keywords
+      sql = <<~SQL
+        SELECT kw, COUNT(*) AS cnt
+        FROM projects, unnest(keywords) AS kw
+        WHERE category = :category
+          AND kw NOT IN (
+            SELECT DISTINCT unnest(keywords)
+            FROM projects
+            WHERE category != :category
+          )
+        GROUP BY kw
+        ORDER BY cnt DESC
+      SQL
+      rows = connection.select_rows(sanitize_sql_array([sql, { category: category }]))
+      keywords = rows.map(&:first) - ignore_words
+      keywords
     end
   end
 
   def self.unique_keywords_for_sub_category(subcategory)
     Rails.cache.fetch("project_unique_keywords_subcategory_#{subcategory}", expires_in: 24.hours) do
-      # Get all keywords from all subcategory
-      all_keywords = Project.where.not(sub_category: subcategory).pluck(:keywords).flatten
-
-      # Get keywords from the specific subcategory
-      subcategory_keywords = Project.where(sub_category: subcategory).pluck(:keywords).flatten
-
-      # Get keywords that only appear in the specific subcategory
-      unique_keywords = subcategory_keywords - all_keywords
-
-      # remove stop words
-      unique_keywords = unique_keywords - ignore_words
-
-      # Group the unique keywords by their values and sort them by the size of each group
-      sorted_keywords = unique_keywords.group_by { |keyword| keyword }.sort_by { |keyword, occurrences| -occurrences.size }.map(&:first)
-      sorted_keywords
+      sql = <<~SQL
+        SELECT kw, COUNT(*) AS cnt
+        FROM projects, unnest(keywords) AS kw
+        WHERE sub_category = :subcategory
+          AND kw NOT IN (
+            SELECT DISTINCT unnest(keywords)
+            FROM projects
+            WHERE sub_category != :subcategory
+          )
+        GROUP BY kw
+        ORDER BY cnt DESC
+      SQL
+      rows = connection.select_rows(sanitize_sql_array([sql, { subcategory: subcategory }]))
+      keywords = rows.map(&:first) - ignore_words
+      keywords
     end
   end
 
@@ -2036,7 +2039,11 @@ class Project < ApplicationRecord
   end
 
   def self.sync_dependencies(min_count: 10)
-    dependencies = Project.reviewed.map(&:dependency_packages).flatten(1).group_by(&:itself).transform_values(&:count).sort_by{|k,v| v}.reverse
+    dependency_counts = Hash.new(0)
+    Project.reviewed.select(:id, :dependencies).find_each(batch_size: 500) do |project|
+      project.dependency_packages.each { |dep| dependency_counts[dep] += 1 }
+    end
+    dependencies = dependency_counts.sort_by { |_k, v| -v }
 
     dependencies.each do |(ecosystem, package_name), count|
       puts "Checking #{ecosystem} #{package_name}"

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -62,9 +62,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
                   'rankings' => { 'average' => 50 }, 'registry' => { 'name' => 'PyPI', 'url' => 'https://pypi.org' },
                   'registry_url' => 'https://pypi.org/project/test-pkg',
                   'maintainers' => [], 'advisories' => [] }]
-    Project.connection.execute(
-      "UPDATE projects SET packages = '#{pkg_data.to_json}'::json WHERE id = #{@project.id}"
-    )
+    @project.update_column(:packages, pkg_data)
 
     get packages_projects_path
     assert_response :success

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -54,4 +54,19 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_nil assigns(:pagy)
   end
+
+  test "packages renders successfully" do
+    pkg_data = [{ 'name' => 'test-pkg', 'ecosystem' => 'pypi', 'downloads' => 1000,
+                  'downloads_period' => 'last-month', 'dependent_packages_count' => 5,
+                  'dependent_repos_count' => 10, 'versions_count' => 3,
+                  'rankings' => { 'average' => 50 }, 'registry' => { 'name' => 'PyPI', 'url' => 'https://pypi.org' },
+                  'registry_url' => 'https://pypi.org/project/test-pkg',
+                  'maintainers' => [], 'advisories' => [] }]
+    Project.connection.execute(
+      "UPDATE projects SET packages = '#{pkg_data.to_json}'::json WHERE id = #{@project.id}"
+    )
+
+    get packages_projects_path
+    assert_response :success
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -354,6 +354,96 @@ class ProjectTest < ActiveSupport::TestCase
     assert facets["language"]["Python"] >= 1
   end
 
+  test "facets results are cached" do
+    Project.create!(
+      url: 'https://github.com/test/facet-cache',
+      name: 'Facet Cache',
+      keywords: ['cached'],
+      repository: { 'language' => 'Ruby' },
+      reviewed: true
+    )
+
+    scope = Project.search('facet cache')
+    first_result = Project.facets(scope)
+    second_result = Project.facets(scope)
+
+    assert_equal first_result, second_result
+  end
+
+  test "unique_keywords_for_category returns keywords exclusive to category" do
+    Project.create!(
+      url: 'https://github.com/test/unique-kw-cat-a',
+      category: 'energy',
+      keywords: ['solar', 'photovoltaic'],
+      reviewed: true
+    )
+    Project.create!(
+      url: 'https://github.com/test/unique-kw-cat-b',
+      category: 'transport',
+      keywords: ['solar', 'electric-vehicle'],
+      reviewed: true
+    )
+
+    Rails.cache.clear
+    unique = Project.unique_keywords_for_category('energy')
+
+    assert_includes unique, 'photovoltaic'
+    refute_includes unique, 'solar'
+  end
+
+  test "unique_keywords_for_sub_category returns keywords exclusive to sub_category" do
+    Project.create!(
+      url: 'https://github.com/test/unique-kw-sub-a',
+      sub_category: 'wind',
+      keywords: ['turbine', 'offshore'],
+      reviewed: true
+    )
+    Project.create!(
+      url: 'https://github.com/test/unique-kw-sub-b',
+      sub_category: 'solar',
+      keywords: ['turbine', 'panel'],
+      reviewed: true
+    )
+
+    Rails.cache.clear
+    unique = Project.unique_keywords_for_sub_category('wind')
+
+    assert_includes unique, 'offshore'
+    refute_includes unique, 'turbine'
+  end
+
+  test "sync_dependencies counts dependency packages across projects" do
+    project_a = Project.create!(
+      url: 'https://github.com/test/sync-dep-a',
+      reviewed: true,
+      dependencies: [
+        { 'filepath' => 'requirements.txt', 'ecosystem' => 'pypi', 'dependencies' => [
+          { 'package_name' => 'numpy', 'ecosystem' => 'pypi', 'direct' => true },
+          { 'package_name' => 'pandas', 'ecosystem' => 'pypi', 'direct' => true }
+        ] }
+      ]
+    )
+    project_b = Project.create!(
+      url: 'https://github.com/test/sync-dep-b',
+      reviewed: true,
+      dependencies: [
+        { 'filepath' => 'requirements.txt', 'ecosystem' => 'pypi', 'dependencies' => [
+          { 'package_name' => 'numpy', 'ecosystem' => 'pypi', 'direct' => true }
+        ] }
+      ]
+    )
+
+    Project.sync_dependencies(min_count: 999)
+
+    numpy_dep = Dependency.find_by(ecosystem: 'pypi', name: 'numpy')
+    assert_not_nil numpy_dep
+    assert_equal 2, numpy_dep.count
+
+    pandas_dep = Dependency.find_by(ecosystem: 'pypi', name: 'pandas')
+    assert_not_nil pandas_dep
+    assert_equal 1, pandas_dep.count
+  end
+
   test "fetch_citation_file sanitizes null bytes from content" do
     project = Project.create!(url: 'https://github.com/test/citation-nullbytes')
     project.stubs(:citation_file_name).returns('CITATION.cff')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,8 +19,7 @@ class ActiveSupport::TestCase
     end
   end
 
-  # If you need transactional fixtures (common for DB tests, less so for controller tests)
-  # self.use_transactional_fixtures = true
+  self.use_transactional_tests = true
 
   # If you need instatiated fixtures
   # fixtures :all


### PR DESCRIPTION
AppSignal showed Puma RSS fluctuating between 528-713MB with `CategoriesController#show` at 1.37B allocations/day, `ProjectsController#search` at 1.29B, and `ProjectsController#packages` at 458K allocations per request. Sidekiq was spiking to 795MB during `sync_dependencies`.

Four fixes:

- **Cache `Project.facets`** for 1 hour, keyed on query SQL. This was running two aggregate queries per request across 111K search requests/day with no caching. Also limits keyword facets to 100 results.
- **Rewrite `unique_keywords_for_category` / `unique_keywords_for_sub_category`** to use SQL with `unnest` and `NOT IN` subquery instead of plucking all keywords from all projects into Ruby twice per call.
- **Sort packages in SQL** using `jsonb_array_elements` instead of loading 500 project rows into Ruby, filtering, and sorting in memory.
- **Use `find_each` in `sync_dependencies`** with `select(:id, :dependencies)` instead of `Project.reviewed.map(&:dependency_packages)` which loaded all 6819 projects into memory at once.