### PR TITLE
Remove unused project proposal form and disable sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   skip_forgery_protection
+  before_action { request.session_options[:skip] = true }
   include Pagy::Backend
 
   rescue_from Pagy::OverflowError do

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -79,36 +79,6 @@ class ProjectsController < ApplicationController
     @pagy, @projects = pagy(@scope)
   end
 
-  def new
-    @project = Project.new
-  end
-
-  def create
-    @project = Project.new(project_params)
-    if @project.valid?
-      @project = Project.find_by(url: params[:project][:url].downcase)
-      if @project.nil?
-
-        @project = Project.new(project_params)
-
-        if @project.save
-          @project.sync_async
-          redirect_to @project
-        else
-          render 'new'
-        end
-      else
-        redirect_to @project
-      end
-    else
-      render 'new'
-    end
-  end
-
-  def project_params
-    params.require(:project).permit(:url, :name, :description)
-  end
-
   def dependencies
     # Use existing Dependency table instead of loading all projects
     @dependency_records = Dependency.where('count > 1').includes(:project).order('count DESC')

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,6 @@
       <%= meta_title %>
     </title>
     <meta name="description" content="<%= meta_description %>">
-    <%= csrf_meta_tags %>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= javascript_include_tag "application" %>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,6 +1,0 @@
-<%= simple_form_for @project do |f| %>
-  <%= f.input :url, label: 'project repository url', placeholder: 'eg: https://github.com/Unidata/siphon' %>
-  <%= f.input :name, placeholder:  'Name of project (optional)' %>
-  <%= f.input :description, placeholder: 'Description of project (optional)' %>
-  <%= f.button :submit, 'Propose project', class: 'btn-primary' %>
-<% end %>

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,7 +1,0 @@
-<div class="container-md">
-  <h2>
-    Propose a new project
-  </h2>
-
-  <%= render 'form' %>
-</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,9 @@ module OST
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.exceptions_app = self.routes
+
+    config.session_store :disabled
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::Cookies
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require 'sidekiq/web'
 require 'sidekiq-status/web'
 
+Sidekiq::Web.use ActionDispatch::Cookies
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_ost_sidekiq_session', path: '/sidekiq'
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
@@ -38,7 +40,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :projects, constraints: { id: /.*/ } do
+  resources :projects, constraints: { id: /.*/ }, only: [:index, :show] do
     collection do
       post :lookup
       get :lookup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ require 'sidekiq/web'
 require 'sidekiq-status/web'
 
 Sidekiq::Web.use ActionDispatch::Cookies
-Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_ost_sidekiq_session', path: '/sidekiq'
+Sidekiq::Web.use ActionDispatch::Session::CookieStore, key: '_ost_sidekiq_session', path: '/sidekiq', secure: Rails.env.production?
 Sidekiq::Web.use Rack::Auth::Basic do |username, password|
   ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))

--- a/test/controllers/cache_headers_test.rb
+++ b/test/controllers/cache_headers_test.rb
@@ -64,19 +64,26 @@ class CacheHeadersTest < ActionDispatch::IntegrationTest
     assert_cache_control "s-maxage=3600"
   end
 
-  test "projects new does not set cache headers" do
-    get new_project_path
+  test "html pages do not set cookies" do
+    get projects_path
     assert_response :success
-    refute_cache_control "s-maxage"
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "project show does not set cookies" do
+    get project_path(@project)
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
+  end
+
+  test "api endpoints do not set cookies" do
+    get api_v1_projects_path
+    assert_response :success
+    assert_nil response.headers['Set-Cookie']
   end
 
   def assert_cache_control(directive)
     cc = response.headers['Cache-Control'] || ''
     assert cc.include?(directive), "Expected Cache-Control to include '#{directive}', got '#{cc}'"
-  end
-
-  def refute_cache_control(directive)
-    cc = response.headers['Cache-Control'] || ''
-    refute cc.include?(directive), "Expected Cache-Control to NOT include '#{directive}', got '#{cc}'"
   end
 end


### PR DESCRIPTION
The `/projects/new` form had no inbound links anywhere in the app, `skip_forgery_protection` was already set so its `authenticity_token` was never checked, and `ProjectsController#create` was an unauthenticated public write. Remove the `new`/`create` actions, the `new.html.erb`/`_form.html.erb` views, and restrict the `projects` resource to `:index, :show` (collection routes kept).

Then the same cookie fix as the other apps: `csrf_meta_tags` in the layout writes `_csrf_token` to the session on every render, which forces `Set-Cookie: _ost_session=...` on every response. Cloudflare (with origin cache control) returns `cf-cache-status: BYPASS` for responses carrying `Set-Cookie`, and APISIX `proxy-cache` never stores them, so the existing `s-maxage` headers are ignored:

```
$ curl -sI https://ost.ecosyste.ms/
set-cookie: _ost_session=...
apisix-cache-status: MISS
cf-cache-status: BYPASS
```

- `config.session_store :disabled` and remove `ActionDispatch::Cookies` / `Session::CookieStore` from the middleware stack
- drop `csrf_meta_tags` from the layout
- `request.session_options[:skip] = true` in `ApplicationController`
- give `Sidekiq::Web` its own session middleware scoped to `/sidekiq`
- tests asserting no `Set-Cookie` on HTML and API responses

`simple_form` and `VotesController#create` are now the only remaining POST surface; both are unused by any view and could go in a follow-up.

Same cookie change as ecosyste-ms/awesome#793, which took `cf-cache-status: BYPASS` to `HIT` at both APISIX and Cloudflare.