### PR TITLE
Ignore unknown release attributes during sync

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2067,7 +2067,7 @@ class Project < ApplicationRecord
 
     releases.each do |release|
       r = Release.find_or_create_by(project_id: id, uuid: release['uuid'])
-      r.update(release.except('release_url'))
+      r.update(Release.sync_attributes(release))
     end
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,4 +1,9 @@
 class Release < ApplicationRecord
+  LOCALLY_MANAGED_ATTRIBUTES = %w[id project_id created_at updated_at].freeze
+
   belongs_to :project
-  
+
+  def self.sync_attributes(attributes)
+    attributes.stringify_keys.slice(*(attribute_names - LOCALLY_MANAGED_ATTRIBUTES))
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -457,4 +457,28 @@ class ProjectTest < ActiveSupport::TestCase
     project.fetch_citation_file
     assert_equal "Title:Test", project.citation_file
   end
+
+  test "sync_releases ignores unknown and locally managed attributes" do
+    project = Project.create!(
+      url: 'https://github.com/test/release-sync',
+      repository: { 'releases_url' => 'https://example.com/releases' }
+    )
+    other_project = Project.create!(url: 'https://github.com/test/other-project')
+    response = stub(
+      success?: true,
+      body: [{
+        'uuid' => 'release-1',
+        'name' => 'Version 1',
+        'immutable' => true,
+        'project_id' => other_project.id
+      }].to_json
+    )
+    project.stubs(:ecosystem_http_client).returns(stub(get: response))
+
+    assert_nothing_raised { project.sync_releases }
+
+    release = project.releases.find_by!(uuid: 'release-1')
+    assert_equal 'Version 1', release.name
+    assert_equal project.id, release.project_id
+  end
 end


### PR DESCRIPTION
Filters release API payloads through the `Release` schema before updating records, so new upstream fields such as `immutable` are ignored.

Keeps `id`, `project_id`, `created_at`, and `updated_at` locally managed, with regression coverage for unknown and locally managed attributes.